### PR TITLE
Add a new action step that creates a new project and imports a package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,10 @@ inputs:
     required: false
     default: ''
     description: 'The android keyaliasPass'
+  packagePath:
+    required: true
+    default: ''
+    description: 'Full path to the .unitypackage file'
   customParameters:
     required: false
     default: ''

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -5,7 +5,8 @@
 #
 
 source /steps/activate.sh
-source /steps/build.sh
+source /steps/createAndImport.sh
+# source /steps/build.sh
 source /steps/return_license.sh
 
 #

--- a/action/steps/createAndImport.sh
+++ b/action/steps/createAndImport.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+#
+# Set project path
+#
+
+UNITY_PROJECT_PATH="$GITHUB_WORKSPACE/$PROJECT_PATH"
+echo "Using project path \"$UNITY_PROJECT_PATH\"."
+
+#
+# Display the name for the build, doubles as the output name
+#
+
+echo "Using build name \"$BUILD_NAME\"."
+
+#
+# Display the build's target platform;
+#
+
+echo "Using build target \"$BUILD_TARGET\"."
+
+#
+# Display build path and file
+#
+
+echo "Using build path \"$BUILD_PATH\" to save file \"$BUILD_FILE\"."
+BUILD_PATH_FULL="$GITHUB_WORKSPACE/$BUILD_PATH"
+CUSTOM_BUILD_PATH="$BUILD_PATH_FULL/$BUILD_FILE"
+
+#
+# Display custom parameters
+#
+echo "Using custom parameters $CUSTOM_PARAMETERS."
+
+# The build specification below may require Unity 2019.2.11f1 or later (not tested below).
+# Reference: https://docs.unity3d.com/2019.3/Documentation/Manual/CommandLineArguments.html
+
+#
+# Build info
+#
+
+echo ""
+echo "###########################"
+echo "#    Current build dir    #"
+echo "###########################"
+echo ""
+
+echo "Creating \"$BUILD_PATH_FULL\" if it does not exist."
+mkdir -p "$BUILD_PATH_FULL"
+ls -alh "$BUILD_PATH_FULL"
+
+echo ""
+echo "###########################"
+echo "#    Project directory    #"
+echo "###########################"
+echo ""
+
+ls -alh $UNITY_PROJECT_PATH
+
+echo ""
+echo "##################################"
+echo "#    Generating unity project    #"
+echo "##################################"
+echo ""
+
+unity-editor \
+  -nographics \
+  -logfile /dev/stdout \
+  -quit \
+  -createProject "$UNITY_PROJECT_PATH"
+
+
+echo ""
+echo "###########################"
+echo "#    Importing Package    #"
+echo "###########################"
+echo ""
+
+unity-editor \
+  -nographics \
+  -projectPath "$UNITY_PROJECT_PATH"\
+  -logfile /dev/stdout \
+  -quit \
+  -importPackage "$PACKAGE_PATH"
+
+# Catch exit code
+BUILD_EXIT_CODE=$?
+
+# Display results
+if [ $BUILD_EXIT_CODE -eq 0 ]; then
+  echo "Build succeeded";
+else
+  echo "Build failed, with exit code $BUILD_EXIT_CODE";
+fi
+
+#
+# Results
+#
+
+echo ""
+echo "###########################"
+echo "#     Build directory     #"
+echo "###########################"
+echo ""
+
+ls -alh "$BUILD_PATH_FULL"

--- a/src/model/build-parameters.js
+++ b/src/model/build-parameters.js
@@ -45,6 +45,7 @@ class BuildParameters {
       androidKeystorePass: Input.androidKeystorePass,
       androidKeyaliasName: Input.androidKeyaliasName,
       androidKeyaliasPass: Input.androidKeyaliasPass,
+      packagePath: Input.packagePath,
       customParameters: Input.customParameters,
       kubeConfig: Input.kubeConfig,
       githubToken: Input.githubToken,

--- a/src/model/docker.js
+++ b/src/model/docker.js
@@ -35,6 +35,7 @@ class Docker {
       androidKeystorePass,
       androidKeyaliasName,
       androidKeyaliasPass,
+      packagePath,
       customParameters,
     } = parameters;
 
@@ -60,6 +61,7 @@ class Docker {
         --env ANDROID_KEYSTORE_PASS="${androidKeystorePass}" \
         --env ANDROID_KEYALIAS_NAME="${androidKeyaliasName}" \
         --env ANDROID_KEYALIAS_PASS="${androidKeyaliasPass}" \
+        --env PACKAGE_PATH="${packagePath}" \
         --env CUSTOM_PARAMETERS="${customParameters}" \
         --env GITHUB_REF \
         --env GITHUB_SHA \

--- a/src/model/input.js
+++ b/src/model/input.js
@@ -75,6 +75,10 @@ class Input {
     return core.getInput('androidKeyaliasPass') || '';
   }
 
+  static get packagePath() {
+    return core.getInput('packagePath') || '';
+  }
+
   static get allowDirtyBuild() {
     const input = core.getInput('allowDirtyBuild') || false;
 


### PR DESCRIPTION
#### Changes
Redo the builder to instead allow creating a new project that then imports a package, thus validating our release .unitypackage.
